### PR TITLE
fix: Use correct secret in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
       PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
       GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The release workflow [failed](https://github.com/guardian/play-passkeyauth/actions/runs/20918062016) because it was using the wrong secret.

Following [example](https://github.com/guardian/etag-caching/blob/a435110ecc31902596b3ec4c7ec5c969ae2545eb/.github/workflows/release.yml) given in [docs](https://github.com/guardian/gha-scala-library-release-workflow/blob/44b129a0fe9d61db6eb0552d60b8c255a57ddc1d/docs/configuration.md#github-workflow).

Tested with [a successful release from this branch](https://github.com/guardian/play-passkeyauth/actions/runs/21283450071).
